### PR TITLE
Experiment form from model

### DIFF
--- a/project_template/forms.py
+++ b/project_template/forms.py
@@ -36,6 +36,14 @@ def get_dict_year_choices():
     return [(date, date) for date in calculate_year_choices()]
 
 
+class PartialModelForm(forms.ModelForm):
+    """
+    A standard Django ModelForm but with no save action
+    """
+    def save(self, *args, **kwargs):
+        raise NotImplemented
+
+
 class TranscribeInitialInformation(forms.Form):
     # Form fields for identifying the politician
     name = forms.CharField(label=_("Care este numele politicianului?"))
@@ -54,17 +62,15 @@ class TranscribeOwnedLandTable(forms.Form):
     count = forms.IntegerField(label="Câte rânduri completate există în tabelul {}?".format(constants.DECLARATION_TABLES['land']), min_value=0)
 
 
-class PartialModelForm(forms.ModelForm):
-    def save(self, *args, **kwargs):
-        raise NotImplemented
-
-
 class TranscribeOwnedLandRowEntry(PartialModelForm):
-    owner_surname = forms.CharField(label="Care este numele proprietarului?")
-    owner_name = forms.CharField(label="Care este prenumele proprietarului")
+    # custom form fields not found in the Model
+    owner_surname = forms.CharField(label=_("Care este numele proprietarului?"))
+    owner_name = forms.CharField(label=_("Care este prenumele proprietarului"))
 
     class Meta:
         model = OwnedLandTableEntry
+        # exclude the Model's table and coowner fields because
+        # they will be handled separately by the Task
         exclude = ['table', 'coowner']
 
 

--- a/project_template/forms.py
+++ b/project_template/forms.py
@@ -23,6 +23,8 @@ from project_template.datamodels.real_estate_type import RealEstateType
 from project_template.datamodels.building_type import BuildingType
 from project_template.datamodels.investment_type import InvestmentType
 
+from project_template.models import OwnedLandTableEntry
+
 
 def calculate_year_choices():
     start_date = 1980
@@ -52,19 +54,18 @@ class TranscribeOwnedLandTable(forms.Form):
     count = forms.IntegerField(label="Câte rânduri completate există în tabelul {}?".format(constants.DECLARATION_TABLES['land']))
 
 
-class TranscribeOwnedLandRowEntry(forms.Form):
-    county = forms.ChoiceField(label="Care este judetul in care se gaseste terenul detinut?", choices=Counties.return_counties())
-    city = forms.CharField(label="Care este localitatea in care se gaseste terenul detinut?")
-    commune = forms.CharField(label="Care este comuna in care se gaseste terenul detinut?")
-    real_estate_type = forms.ChoiceField(label="Care este categoria de teren?", choices=RealEstateType.return_as_iterable())
-    ownership_start_year = forms.ChoiceField(label="Care este anul cand terenul a fost dobandit?", choices=get_dict_year_choices)
-    surface_area = forms.FloatField(label="Care este suprafata terenului? (mp)")
-    percent_of_ownership = forms.IntegerField(label="Care este cota parte din acest teren? (in procente)", max_value=100, min_value=0)
-    taxable_value = forms.FloatField(label="Care este valoarea impozabilă a terenului? (dacă există)", required=False)
-    taxable_value_currency = forms.ChoiceField(label="Care este valuta in care este exprimata valoarea impozabilă a terenului?", choices=Currency.return_as_iterable())
-    attainment_type = forms.ChoiceField(label="Care este modul in care terenul a fost dobandit?", choices=AttainmentType.return_as_iterable())
+class PartialModelForm(forms.ModelForm):
+    def save(self, *args, **kwargs):
+        raise NotImplemented
+
+
+class TranscribeOwnedLandRowEntry(PartialModelForm):
     owner_surname = forms.CharField(label="Care este numele proprietarului?")
     owner_name = forms.CharField(label="Care este prenumele proprietarului")
+
+    class Meta:
+        model = OwnedLandTableEntry
+        exclude = ['table', 'coowner']
 
 
 class TranscribeOwnedBuildingsTable(forms.Form):

--- a/project_template/tasks.py
+++ b/project_template/tasks.py
@@ -41,19 +41,10 @@ class TaskOwnedLandRowEntry(DigitalizationTask):
             surname=verified_data['owner_surname']
         )
 
+        map(verified_data.pop, ['name', 'surname'])
         owned_land, created = models.OwnedLandTableEntry.objects.get_or_create(
             coowner=owner_person,
-            county=verified_data['county'],
-            city=verified_data['city'],
-            commune=verified_data['commune'],
-            category=verified_data['real_estate_type'],
-            acquisition_year=verified_data['ownership_start_year'],
-            surface=verified_data['surface_area'],
-            share_ratio=verified_data['percent_of_ownership'],
-            taxable_value=verified_data['taxable_value'],
-            taxable_value_currency=verified_data['taxable_value_currency'],
-            attainment_type=verified_data['attainment_type'],
-            observations=verified_data.get('observations', '')
+            **verified_data,
         )
 
 

--- a/project_template/tasks.py
+++ b/project_template/tasks.py
@@ -41,13 +41,18 @@ class TaskOwnedLandRowEntry(DigitalizationTask):
             surname=verified_data['owner_surname']
         )
 
-        map(verified_data.pop, ['name', 'surname'])
+        # Remove the separate owner name fields, because the TableEntry
+        # requires an owner Person
+        del verified_data['owner_name']
+        del verified_data['owner_surname']
+
         owned_land, created = models.OwnedLandTableEntry.objects.get_or_create(
             coowner=owner_person,
             **verified_data,
         )
 
 
+@register()
 class TaskOwnedLandTable(CountTableRowsTask):
     task_form = forms.TranscribeOwnedLandTable
     storage_model = models.OwnedLandTable
@@ -474,7 +479,6 @@ class TaskOwnedIncomeFromInvestmentsRowEntry(DigitalizationTask):
         )
 
 
-@register()
 class TaskOwnedIncomeFromInvestmentsTable(CountTableRowsTask):
     task_form = forms.TranscribeOwnedIncomeFromInvestmentsTable
     storage_model = models.OwnedIncomeFromInvestmentsTable


### PR DESCRIPTION
Refactor one Model + RowEntry + Task as an experiment to prevent field name (& constraints) duplication across them.


`OwnedLandTableEntry(CommonInfo)` is the chosen model.

`TranscribeOwnedLandRowEntry(PartialModelForm)` is now based on Django's ModelForm, except that we remove the default `save` method which is not needed. Custom form fields which are not found in the Model must be added here, while fields which shouldn't be on the public form (like Owner Person) must be removed.

`TaskOwnedLandRowEntry(DigitalizationTask)` processes the custom form fields and removes them before saving the TableEntry.

TODO:
`owner_surname` and `owner_name` custom fields are shared by several forms. Maybe create a Mixin for them?